### PR TITLE
Fixed a crash when chronoshifting units on TEMPERATE maps

### DIFF
--- a/sequences/misc.yaml
+++ b/sequences/misc.yaml
@@ -11,7 +11,7 @@ overlay:
 		Start: 1
 	target-valid-snow: place
 		Start: 2
-	target-valid-temperat: place
+	target-valid-temperate: place
 
 poweroff:
 	offline: poweroff


### PR DESCRIPTION
A regression from https://github.com/OpenRA/ra2/pull/30.
